### PR TITLE
Fix wrong linking to duplicated headings

### DIFF
--- a/markdown-toc.sh
+++ b/markdown-toc.sh
@@ -3,6 +3,7 @@
 FILE=${1:?No file was specified as first argument}
 
 declare -a TOC
+declare -A TOC_MAP
 CODE_BLOCK=0
 CODE_BLOCK_REGEX='^```'
 HEADING_REGEX='^#{1,}'
@@ -62,5 +63,14 @@ for LINE in "${TOC[@]}"; do
     LINK=$(tr -s "-" <<< "${LINK}")
 
     # Print in format [Very Special Heading](#very-special-heading)
-    echo "[${LINE#\#* }](#${LINK})"
+    # Make sure to add "-X" suffix with correct increment for headings that are repeated
+    INDEX=${TOC_MAP[${LINE}]}
+    if [[ "${INDEX}" != "" ]]; then
+        INDEX=$(( INDEX + 1 ))
+        TOC_MAP[${LINE}]=${INDEX}
+        echo "[${LINE#\#* }](#${LINK}-${INDEX})"
+    else
+        TOC_MAP[${LINE}]=0
+        echo "[${LINE#\#* }](#${LINK})"
+    fi
 done

--- a/tests/readme-with-identical-headings-result.md
+++ b/tests/readme-with-identical-headings-result.md
@@ -1,0 +1,9 @@
+## Table of Contents
+
+- [My Awesome Project](#my-awesome-project)
+  - [It's Awesome](#its-awesome)
+    - [Why?](#why)
+  - [It's Groundbreaking](#its-groundbreaking)
+    - [Why?](#why-1)
+  - [It's Unbelievable](#its-unbelievable)
+    - [Why?](#why-2)

--- a/tests/readme-with-identical-headings.md
+++ b/tests/readme-with-identical-headings.md
@@ -1,0 +1,23 @@
+# My Awesome Project
+
+## Table of Contents
+
+- [My Awesome Project](#my-awesome-project)
+  - [It's Awesome](#its-awesome)
+    - [Why?](#why)
+  - [It's Groundbreaking](#its-groundbreaking)
+    - [Why?](#why-1)
+  - [It's Unbelievable](#its-unbelievable)
+    - [Why?](#why-2)
+
+## It's Awesome
+
+### Why?
+
+## It's Groundbreaking
+
+### Why?
+
+## It's Unbelievable
+
+### Why?

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "Test markdown file with duplicated headings" {
+	run diff <(./markdown-toc.sh tests/readme-with-identical-headings.md) tests/readme-with-identical-headings-result.md
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
When there are more than 1 headings with the same name, they currently end up having the same link name which breaks the "href" functionality (not navigated to the heading after pointer click).

This commit fixes the issue by introducing associative array that tracks amount of duplicated headings and appends suffix "-<number>" to the link.

Closes https://github.com/Lirt/markdown-toc-bash/issues/9